### PR TITLE
Fix tests with testtools 1.2.0 and above.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,12 @@ subunit release notes
 NEXT (In development)
 ---------------------
 
+BUGFIXES
+~~~~~~~~
+
+* Tests have been fixed with testtools 1.2.0 and above.
+  (Robert Collins)
+
 0.0.21
 ------
 

--- a/python/subunit/tests/test_run.py
+++ b/python/subunit/tests/test_run.py
@@ -80,9 +80,14 @@ class TestSubunitTestRunner(TestCase):
             self.fail("SystemExit raised")
         self.assertThat(bytestream.getvalue(), StartsWith(_b('\xb3')))
 
+    class ExitingTest(TestCase):
+        def test_exit(self):
+            raise SystemExit(0)
+
     def test_exits_nonzero_when_execution_errors(self):
         bytestream = io.BytesIO()
         stream = io.TextIOWrapper(bytestream, encoding="utf8")
-        exc = self.assertRaises(Exception, run.main,
-                argv=["progName", "subunit.tests.test_run.TestSubunitTestRunner.MissingTest"],
+        exc = self.assertRaises(SystemExit, run.main,
+                argv=["progName", "subunit.tests.test_run.TestSubunitTestRunner.ExitingTest"],
                 stdout=stream)
+        self.assertEqual(0, exc.args[0])


### PR DESCRIPTION
Import errors don't break execution or listing now in testtools, so to
test execution breaking we have to be a little bit more direct.
