### PR TITLE
Forward stdout content in subunit-2to1.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,9 @@ NEXT (In development)
 BUGFIXES
 ~~~~~~~~
 
+* Unencapsulated strings and encapsulated stdout will be forwarded by
+  subunit-2to1. (Robert Collins, #1400519)
+
 * SUBUNIT_FORMATTER which has not been honoured for years is now removed from 
   the codebase. (Jelmer Vernooij)
 

--- a/filters/subunit-2to1
+++ b/filters/subunit-2to1
@@ -19,10 +19,14 @@
 from optparse import OptionParser
 import sys
 
-from testtools import StreamToExtendedDecorator
+from testtools import (
+    StreamToExtendedDecorator,
+    StreamResultRouter,
+    )
 
 from subunit import ByteStreamToStreamResult, TestProtocolClient
 from subunit.filters import find_stream, run_tests_from_stream
+from subunit.test_results import CatFiles
 
 
 def make_options(description):
@@ -36,7 +40,9 @@ def main():
     case = ByteStreamToStreamResult(
         find_stream(sys.stdin, args), non_subunit_name='stdout')
     result = StreamToExtendedDecorator(TestProtocolClient(sys.stdout))
-    # What about stdout chunks?
+    result = StreamResultRouter(result)
+    cat = CatFiles(sys.stdout)
+    result.add_rule(cat, 'test_id', test_id=None)
     result.startTestRun()
     case.run(result)
     result.stopTestRun()


### PR DESCRIPTION
It was always intended to be forwarded.

Closes-Bug: #1400519
