### PR TITLE
Correctly decode binary to utf8 string

### DIFF
--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -556,7 +556,7 @@ class TestProtocolServer(object):
     def _handleTime(self, offset, line):
         # Accept it, but do not do anything with it yet.
         try:
-            event_time = iso8601.parse_date(line[offset:-1])
+            event_time = iso8601.parse_date(line[offset:-1].decode('utf8'))
         except TypeError:
             raise TypeError(_u("Failed to parse %r, got %r")
                 % (line, sys.exec_info[1]))


### PR DESCRIPTION
This patch solves error:
 Expecting a string b'2014-12-16 20:42:25.441886Z'

Related-Bug: #1403214