### PR TITLE
Added a go implementation of the subunit protocol.

### DIFF
--- a/go/base_test.go
+++ b/go/base_test.go
@@ -1,0 +1,28 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (c) 2015 Canonical Ltd
+ *
+ * Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+ * license at the users choice. A copy of both licenses are available in the
+ * project source as Apache-2.0 and BSD. You may not use this file except in
+ * compliance with one of these two licences.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * license you chose for the specific language governing permissions and
+ * limitations under that license.
+ *
+ */
+
+package subunit_test
+
+import (
+	"testing"
+
+	check "gopkg.in/check.v1"
+)
+
+// Hook up go check into the "go test" runner.
+func Test(t *testing.T) { check.TestingT(t) }

--- a/go/reference_test.go
+++ b/go/reference_test.go
@@ -1,0 +1,114 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (c) 2015 Canonical Ltd
+ *
+ * Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+ * license at the users choice. A copy of both licenses are available in the
+ * project source as Apache-2.0 and BSD. You may not use this file except in
+ * compliance with one of these two licences.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * license you chose for the specific language governing permissions and
+ * limitations under that license.
+ *
+ */
+
+package subunit_test
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/testing-cabal/subunit/go"
+
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&SubunitReferenceSuite{})
+
+type SubunitReferenceSuite struct {
+	stream *subunit.StreamResultToBytes
+}
+
+func isSubunitInstalled() bool {
+	cmd := exec.Command("python", "-c", "import subunit")
+	err := cmd.Run()
+	return err == nil
+}
+
+func makePythonArgs(e subunit.Event) string {
+	args := fmt.Sprintf("test_id=%q, test_status=%q, runnable=False", e.TestID, e.Status)
+	if !e.Timestamp.IsZero() {
+		args += fmt.Sprintf(", timestamp=datetime.datetime(%d, %d, %d, %d, %d, %d, %d, iso8601.Utc())",
+			e.Timestamp.Year(), e.Timestamp.Month(), e.Timestamp.Day(), e.Timestamp.Hour(),
+			e.Timestamp.Minute(), e.Timestamp.Second(), e.Timestamp.Nanosecond()/1000)
+	}
+	if e.MIME != "" {
+		args += fmt.Sprintf(", mime_type=%q", e.MIME)
+	}
+	if e.FileName != "" {
+		args += fmt.Sprintf(", file_name=%q, file_bytes=b%q", e.FileName, string(e.FileBytes[:]))
+	}
+	return args
+}
+
+func (s *SubunitReferenceSuite) SetUpSuite(c *check.C) {
+	if !isSubunitInstalled() {
+		c.Skip("subunit is not installed")
+	}
+}
+
+var referencetests = []subunit.Event{
+	// Status tests.
+	{TestID: "existing-test", Status: "exists"},
+	{TestID: "progressing-test", Status: "inprogress"},
+	{TestID: "successful-test", Status: "success"},
+	{TestID: "unexpected-successful-test", Status: "uxsuccess"},
+	{TestID: "skipped-test", Status: "skip"},
+	{TestID: "failed-test", Status: "fail"},
+	{TestID: "expected-failed-test", Status: "xfail"},
+
+	// Different test id lengths.
+	{TestID: "test-id (1 byte)", Status: "exists"},
+	{TestID: "test-id-with-63-chars (1 byte____)" + strings.Repeat("_", 63-34), Status: "exists"},
+	{TestID: "test-id-with-64-chars (2 bytes___)" + strings.Repeat("_", 64-34), Status: "exists"},
+	{TestID: "test-id-with-16383-chars (2 bytes)" + strings.Repeat("_", 16383-34), Status: "exists"},
+	{TestID: "test-id-with-16384-chars (3 bytes)" + strings.Repeat("_", 16384-34), Status: "exists"},
+	// We can't test IDs with more length bytes through the command line.
+
+	// Test with timestamp.
+	// Round to microseconds because python's datetime does not accept nanoseconds.
+	{TestID: "test-with-timestamp", Status: "success",
+		Timestamp: time.Now().UTC().Round(time.Microsecond)},
+
+	// Test with MIME and file content.
+	{TestID: "test-with-mime", Status: "fail",
+		MIME: "text/plain;charset=utf8", FileName: "reason", FileBytes: []byte("error")},
+}
+
+func (s *SubunitReferenceSuite) TestReference(c *check.C) {
+	for _, e := range referencetests {
+		var goOutput bytes.Buffer
+		stream := &subunit.StreamResultToBytes{Output: &goOutput}
+		err := stream.Status(e)
+		c.Check(err, check.IsNil, check.Commentf("Error running the go version of subunit: %s", err))
+
+		cmd := exec.Command("python", "-c", fmt.Sprintf(
+			// FIXME the runnable flag must be a parameter. --elopio - 2015-08-31
+			"import datetime; import subunit; import sys; from subunit import iso8601; "+
+				"subunit.StreamResultToBytes(sys.stdout).status(%s)",
+			makePythonArgs(e)))
+		pythonOutput, err := cmd.Output()
+		c.Check(err, check.IsNil,
+			check.Commentf("Error runninng the python version of subunit: %s", err))
+
+		c.Check(goOutput.Bytes(), check.DeepEquals, pythonOutput,
+			check.Commentf("Wrong stream for event %v", e))
+	}
+}

--- a/go/subunit.go
+++ b/go/subunit.go
@@ -1,0 +1,265 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (c) 2015 Canonical Ltd
+ *
+ * Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+ * license at the users choice. A copy of both licenses are available in the
+ * project source as Apache-2.0 and BSD. You may not use this file except in
+ * compliance with one of these two licences.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * license you chose for the specific language governing permissions and
+ * limitations under that license.
+ *
+ */
+
+// Package subunit provides a writer of the Subunit v2 protocol.
+package subunit
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"time"
+)
+
+// ErrPacketLen represents an unhandled packet length error
+type ErrPacketLen struct {
+	Length int
+}
+
+func (e *ErrPacketLen) Error() string {
+	return fmt.Sprintf("packet too big (%d bytes)", e.Length)
+}
+
+// ErrNumber represents an error for a number that is over the size
+type ErrNumber struct {
+	Number int
+}
+
+func (e *ErrNumber) Error() string {
+	return fmt.Sprintf("number too big (%d)", e.Number)
+}
+
+const (
+	signature byte = 0xb3
+	// Flags high byte
+	version          byte = 0x2
+	testIDPresent    byte = 0x8
+	timestampPresent byte = 0x2
+	// Flags low byte
+	fileContentPresent byte = 0x40
+	mimePresent        byte = 0x20
+)
+
+var status = map[string]byte{
+	"exists":     0x1,
+	"inprogress": 0x2,
+	"success":    0x3,
+	"uxsuccess":  0x4,
+	"skip":       0x5,
+	"fail":       0x6,
+	"xfail":      0x7,
+}
+
+func makeLen(baseLen int) (length int, err error) {
+	length = baseLen + 4 // Add the length of the CRC32.
+	// We need to take into account the variable length of the length field itself.
+	switch {
+	case length <= 62:
+		// Fits in one byte.
+		length++
+	case length <= 16381:
+		// Fits in two bytes.
+		length += 2
+	case length <= 4194300:
+		// Fits in three bytes.
+		length += 3
+	default:
+		err = &ErrPacketLen{length}
+	}
+
+	return length, err
+}
+
+// StreamResultToBytes is an implementation of the StreamResult API that converts calls to bytes.
+type StreamResultToBytes struct {
+	Output io.Writer
+}
+
+// Event is a status or a file attachment event.
+type Event struct {
+	TestID    string
+	Status    string
+	Timestamp time.Time
+	FileName  string
+	FileBytes []byte
+	MIME      string
+}
+
+type packetPart struct {
+	bytes []byte
+	err   error
+}
+
+func (e *Event) write(writer io.Writer) error {
+	// PACKET := SIGNATURE FLAGS PACKET_LENGTH TIMESTAMP? TESTID? TAGS? MIME? FILECONTENT?
+	//           ROUTING_CODE? CRC32
+
+	flagsChan := make(chan []byte)
+	go e.makeFlags(flagsChan)
+
+	timestampChan := make(chan packetPart)
+	go e.makeTimestamp(timestampChan)
+
+	idChan := make(chan packetPart)
+	go e.makeTestID(idChan)
+
+	mimeChan := make(chan packetPart)
+	go e.makeMIME(mimeChan)
+
+	fileContentChan := make(chan packetPart)
+	go e.makeFileContent(fileContentChan)
+
+	// We construct a temporary buffer because we won't know the length until it's finished.
+	// Then we insert the length.
+	var bTemp bytes.Buffer
+	bTemp.WriteByte(signature)
+	bTemp.Write(<-flagsChan)
+	for _, part := range []packetPart{<-timestampChan, <-idChan, <-mimeChan, <-fileContentChan} {
+		if part.err != nil {
+			return part.err
+		}
+		bTemp.Write(part.bytes)
+	}
+
+	length, err := makeLen(bTemp.Len())
+	if err != nil {
+		return err
+	}
+	// Insert the length.
+	var b bytes.Buffer
+	b.Write(bTemp.Next(3)) // signature (1 byte) and flags (2 bytes)
+	writeNumber(&b, length)
+	b.Write(bTemp.Next(bTemp.Len()))
+
+	// Add the CRC32
+	crc := crc32.ChecksumIEEE(b.Bytes())
+	binary.Write(&b, binary.BigEndian, crc)
+
+	_, err = writer.Write(b.Bytes())
+	return err
+}
+
+func (e *Event) makeFlags(c chan<- []byte) {
+	flags := make([]byte, 2, 2)
+	flags[0] = version << 4
+	if e.TestID != "" {
+		flags[0] = flags[0] | testIDPresent
+	}
+	if !e.Timestamp.IsZero() {
+		flags[0] = flags[0] | timestampPresent
+	}
+	if e.FileName != "" {
+		flags[1] = flags[1] | fileContentPresent
+	}
+	if e.MIME != "" {
+		flags[1] = flags[1] | mimePresent
+	}
+	flags[1] = flags[1] | status[e.Status]
+	c <- flags
+}
+
+func (e *Event) makeTestID(c chan<- packetPart) {
+	var testID bytes.Buffer
+	var err error
+	if e.TestID != "" {
+		err = writeUTF8(&testID, e.TestID)
+	}
+	c <- packetPart{testID.Bytes(), err}
+}
+
+func (e *Event) makeTimestamp(c chan<- packetPart) {
+	var timestamp bytes.Buffer
+	var err error
+	if !e.Timestamp.IsZero() {
+		err = binary.Write(&timestamp, binary.BigEndian, uint32(e.Timestamp.Unix()))
+		if err == nil {
+			err = writeNumber(&timestamp, int(e.Timestamp.UnixNano()%1000000000))
+		}
+	}
+	c <- packetPart{timestamp.Bytes(), err}
+}
+
+func (e *Event) makeMIME(c chan<- packetPart) {
+	var mime bytes.Buffer
+	var err error
+	if e.MIME != "" {
+		err = writeUTF8(&mime, e.MIME)
+	}
+	c <- packetPart{mime.Bytes(), err}
+}
+
+func (e *Event) makeFileContent(c chan<- packetPart) {
+	var fileContent bytes.Buffer
+	var err error
+	if e.FileName != "" {
+		err = writeUTF8(&fileContent, e.FileName)
+		if err == nil {
+			err = writeNumber(&fileContent, len(e.FileBytes))
+		}
+		if err == nil {
+			_, err = fileContent.Write(e.FileBytes)
+		}
+	}
+	c <- packetPart{fileContent.Bytes(), err}
+}
+
+func writeUTF8(b io.Writer, s string) error {
+	err := writeNumber(b, len(s))
+	if err != nil {
+		return err
+	}
+	_, err = io.WriteString(b, s)
+	return err
+}
+
+func writeNumber(b io.Writer, num int) (err error) {
+	// The first two bits encode the size:
+	// 00 = 1 byte
+	// 01 = 2 bytes
+	// 10 = 3 bytes
+	// 11 = 4 bytes
+	switch {
+	case num < 64: // 2^(8-2)
+		// Fits in one byte.
+		binary.Write(b, binary.BigEndian, uint8(num))
+	case num < 16384: // 2^(16-2)
+		// Fits in two bytes.
+		binary.Write(b, binary.BigEndian, uint16(num|0x4000)) // Set the size to 01.
+	case num < 4194304: // 2^(24-2)
+		// Fits in three bytes.
+		// Drop the two least significant bytes and set the size to 10.
+		binary.Write(b, binary.BigEndian, uint8((num>>16)|0x80))
+		// Drop the two most significant bytes.
+		binary.Write(b, binary.BigEndian, uint16(num&0xffff))
+	case num < 1073741824: // 2^(32-2):
+		// Fits in four bytes.
+		// Set the size to 11.
+		binary.Write(b, binary.BigEndian, uint32(num|0xc0000000))
+	default:
+		err = &ErrNumber{num}
+	}
+
+	return err
+}
+
+// Status informs the result about a test status.
+func (s *StreamResultToBytes) Status(e Event) error {
+	return e.write(s.Output)
+}

--- a/go/subunit_test.go
+++ b/go/subunit_test.go
@@ -1,0 +1,263 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (c) 2015 Canonical Ltd
+ *
+ * Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+ * license at the users choice. A copy of both licenses are available in the
+ * project source as Apache-2.0 and BSD. You may not use this file except in
+ * compliance with one of these two licences.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * license you chose for the specific language governing permissions and
+ * limitations under that license.
+ *
+ */
+
+package subunit_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"hash/crc32"
+	"strings"
+	"time"
+
+	"github.com/testing-cabal/subunit/go"
+
+	"gopkg.in/check.v1"
+)
+
+var _ = check.Suite(&SubunitSuite{})
+
+type SubunitSuite struct {
+	stream *subunit.StreamResultToBytes
+	output bytes.Buffer
+}
+
+func (s *SubunitSuite) readNumber() int {
+	byte1 := s.output.Next(1)[0]
+	// Get the first two bits, shift them to the right and add one.
+	size := ((byte1 & 0xc0) >> 6) + 1
+	// Unset the first two bits.
+	b1Value := uint8(byte1) & 0x3f
+	switch size {
+	case 1:
+		return int(b1Value)
+	case 2:
+		// Add the second byte.
+		return int((int16(b1Value) << 8) | int16(s.output.Next(1)[0]))
+	case 3:
+		// Add the second and third bytes.
+		return int(int32(b1Value)<<16 | int32(s.output.Next(1)[0])<<8 |
+			int32(s.output.Next(1)[0]))
+	case 4:
+		// Add the second, third and fourth bytes.
+		return int(int32(b1Value)<<24 | int32(s.output.Next(1)[0])<<16 |
+			int32(s.output.Next(1)[0])<<8 | int32(s.output.Next(1)[0]))
+	}
+	// Impossible to get here.
+	panic("Something wrong happened reading the number")
+}
+
+func (s *SubunitSuite) SetUpSuite(c *check.C) {
+	s.stream = &subunit.StreamResultToBytes{Output: &s.output}
+}
+
+func (s *SubunitSuite) SetUpTest(c *check.C) {
+	s.output.Reset()
+}
+
+func (s *SubunitSuite) TestPacketMustContainSignature(c *check.C) {
+	s.stream.Status(subunit.Event{TestID: "dummytest", Status: "dummystatus"})
+	signature := s.output.Next(1)[0]
+	c.Assert(int(signature), check.Equals, 0xb3,
+		check.Commentf("Wrong signature"))
+}
+
+func (s *SubunitSuite) TestPacketMustContainVersion2Flag(c *check.C) {
+	s.stream.Status(subunit.Event{TestID: "dummytest", Status: "dummystatus"})
+	s.output.Next(1) // skip the signature.
+	flags := s.output.Next(2)
+	version := flags[0] >> 4 // 4 first bits of the first byte.
+	c.Assert(version, check.Equals, uint8(0x2), check.Commentf("Wrong version"))
+}
+
+func (s *SubunitSuite) TestWithoutFlagsPacketMustNotSetAnyPresentFlag(c *check.C) {
+	s.stream.Status(subunit.Event{})
+	s.output.Next(1) // skip the signature
+	flags := s.output.Next(2)
+	flagsHighByte := flags[0] & 0xf // Remove the version, 4 first bits.
+	flagsLowByte := flags[1]
+	c.Check(flagsHighByte, check.Equals, uint8(0x0), check.Commentf("Wrong flags high byte"))
+	c.Check(flagsLowByte, check.Equals, uint8(0x0), check.Commentf("Wrong flags low byte"))
+}
+
+func (s *SubunitSuite) TestWithIDPacketMustSetPresentFlag(c *check.C) {
+	s.stream.Status(subunit.Event{TestID: "test-id", Status: "dummystatus"})
+	s.output.Next(1) // skip the signature.
+	flags := s.output.Next(2)
+	testIDPresent := flags[0] & 0x8 // bit 11.
+	c.Assert(testIDPresent, check.Equals, uint8(0x8),
+		check.Commentf("Test ID present flag is not set"))
+}
+
+var statustests = []struct {
+	status string
+	flag   byte
+}{
+	{"", 0x0},
+	{"undefined", 0x0},
+	{"exists", 0x1},
+	{"inprogress", 0x2},
+	{"success", 0x3},
+	{"uxsuccess", 0x4},
+	{"skip", 0x5},
+	{"fail", 0x6},
+	{"xfail", 0x7},
+}
+
+func (s *SubunitSuite) TestPacketStatusFlag(c *check.C) {
+	for _, t := range statustests {
+		s.output.Reset()
+		s.stream.Status(subunit.Event{TestID: "dummytest", Status: t.status})
+		s.output.Next(1) // skip the signature.
+		flags := s.output.Next(2)
+		testStatus := flags[1] & 0x7 // Last three bits of the second byte.
+		c.Check(testStatus, check.Equals, t.flag,
+			check.Commentf("Wrong status for %s", t.status))
+	}
+}
+
+func (s *SubunitSuite) TestPacketLength(c *check.C) {
+	s.stream.Status(subunit.Event{TestID: "", Status: "dummystatus"})
+	s.output.Next(3) // skip the signature (1 byte) and the flags (2 bytes)
+	length := s.output.Next(1)[0]
+	// signature (1 byte) + flags (2 bytes) + length (2 bytes) + CRC32 (4 bytes)
+	var expectedLength byte = 8
+	c.Assert(length, check.Equals, expectedLength, check.Commentf("Wrong length"))
+}
+
+func (s *SubunitSuite) TestPacketCRC32(c *check.C) {
+	s.stream.Status(subunit.Event{TestID: "", Status: ""})
+	// skip the signature (1 byte), the flags (2 bytes) and the length (1 byte)
+	s.output.Next(4)
+	crc := s.output.Next(4)
+	expectedCRC32 := make([]byte, 4)
+	binary.BigEndian.PutUint32(expectedCRC32,
+		// signature = 0xb3
+		// flags with only version = 0x20 0x0
+		// size = 0x8
+		crc32.ChecksumIEEE([]byte{0xb3, 0x20, 0x0, 0x8}))
+	c.Assert(crc, check.DeepEquals, expectedCRC32, check.Commentf("Wrong CRC32"))
+	// Check against a CRC generated with python's subunit.
+	c.Assert(crc, check.DeepEquals, []byte{0x18, 0x15, 0xf0, 0xba},
+		check.Commentf("Wrong CRC32"))
+}
+
+var idtests = []struct {
+	testIDPrefix  string
+	testIDLen     int
+	packetLenSize int // The number of bytes in the packet length.
+}{
+	{"test-id (1 byte)", 16, 1},
+	{"test-id-with-63-chars (1 byte)", 63, 2},
+	{"test-id-with-64-chars (2 bytes)", 64, 2},
+	{"test-id-with-16383-chars (2 bytes)", 16383, 3},
+	{"test-id-with-16384-chars (3 bytes)", 16384, 3},
+	// The size limit of the packet is 4194303. This is the biggest name possible.
+	{"test-id-with-4194290-chars (3 bytes)", 4194290, 3},
+}
+
+func (s *SubunitSuite) TestPacketTestID(c *check.C) {
+	for _, t := range idtests {
+		s.output.Reset()
+		testID := t.testIDPrefix + strings.Repeat("_", t.testIDLen-len(t.testIDPrefix))
+		s.stream.Status(subunit.Event{TestID: testID, Status: ""})
+		// skip the signature (1 byte) and the flags (2 bytes)
+		s.output.Next(3)
+		// skip the packet length (variable size)
+		s.readNumber()
+		idLen := s.readNumber()
+		c.Check(idLen, check.Equals, len(testID), check.Commentf("Wrong length"))
+		id := string(s.output.Next(idLen))
+		c.Check(id, check.Equals, testID, check.Commentf("Wrong ID"))
+	}
+}
+
+func (s *SubunitSuite) TestWithTimestampPacketMustSetPresentFlag(c *check.C) {
+	s.stream.Status(subunit.Event{Timestamp: time.Now()})
+	s.output.Next(1) // skip the signature.
+	flags := s.output.Next(2)
+	testIDPresent := flags[0] & 0x2 // bit 9.
+	c.Assert(testIDPresent, check.Equals, uint8(0x2),
+		check.Commentf("Timestamp present flag is not set"))
+}
+
+func (s *SubunitSuite) TestPacketTimestamp(c *check.C) {
+	t := time.Now()
+	s.stream.Status(subunit.Event{Timestamp: t})
+	// skip the signature (1 byte) and the flags (2 bytes)
+	s.output.Next(3)
+	// skip the packet length (variable size)
+	s.readNumber()
+	var sec uint32
+	secondsBytes := s.output.Next(4)
+	err := binary.Read(bytes.NewReader(secondsBytes), binary.BigEndian, &sec)
+	c.Assert(err, check.IsNil, check.Commentf("Error reading the timestamp seconds: %s", err))
+	nsec := s.readNumber()
+
+	timestamp := time.Unix(int64(sec), int64(nsec))
+	c.Assert(timestamp, check.Equals, t, check.Commentf("Wrong timestamp"))
+}
+
+func (s *SubunitSuite) TestWithMIMEPacketMustSetPresentFlag(c *check.C) {
+	s.stream.Status(subunit.Event{MIME: "dummy"})
+	s.output.Next(1) // skip the signature.
+	flags := s.output.Next(2)
+	mimePresent := flags[1] & 0x20 // bit 5.
+	c.Assert(mimePresent, check.Equals, uint8(0x20),
+		check.Commentf("MIME present flag not set."))
+}
+
+func (s *SubunitSuite) TestPacketMIME(c *check.C) {
+	testMIME := "text/plain;charset=utf8"
+	s.stream.Status(subunit.Event{MIME: testMIME})
+	// skip the signature (1 byte) and the flags (2 bytes)
+	s.output.Next(3)
+	// skip the packet length (variable size)
+	s.readNumber()
+	idLen := s.readNumber()
+	c.Check(idLen, check.Equals, len(testMIME), check.Commentf("Wrong length"))
+	mime := string(s.output.Next(idLen))
+	c.Check(mime, check.Equals, testMIME, check.Commentf("Wrong ID"))
+}
+
+func (s *SubunitSuite) TestWithFileContentPacketMustSetPresentFlag(c *check.C) {
+	s.stream.Status(subunit.Event{FileName: "dummy"})
+	s.output.Next(1) // skip the signature.
+	flags := s.output.Next(2)
+	mimePresent := flags[1] & 0x40 // bit 6.
+	c.Assert(mimePresent, check.Equals, uint8(0x40),
+		check.Commentf("File content present flag not set."))
+}
+
+func (s *SubunitSuite) TestFileContents(c *check.C) {
+	testFileName := "testfilename"
+	testFileBytes := []byte{0x1, 0xb, 0xf0}
+	s.stream.Status(subunit.Event{FileName: testFileName, FileBytes: testFileBytes})
+	// skip the signature (1 byte) and the flags (2 bytes)
+	s.output.Next(3)
+	// skip the packet length (variable size)
+	s.readNumber()
+	fileNameLen := s.readNumber()
+	c.Check(fileNameLen, check.Equals, len(testFileName), check.Commentf("Wrong file name length"))
+	fileName := string(s.output.Next(fileNameLen))
+	c.Check(fileName, check.Equals, testFileName, check.Commentf("Wrong file name"))
+	contentLen := s.readNumber()
+	c.Check(contentLen, check.Equals, len(testFileBytes), check.Commentf("Wrong content length"))
+	content := s.output.Next(contentLen)
+	c.Check(content, check.DeepEquals, testFileBytes, check.Commentf("Wrong content"))
+}


### PR DESCRIPTION
We have finished the implementation for files, so I'm happy now sending it upstream. We are stillmissing test_tags, runnable, eof and route_code. I'll be implementing them as time permits.

I'm not sure what to do with the travis tests. I can try to make a yaml that supports python and go, but that's all a big mess. See travis-ci/travis-ci#4090
An alternative would be to use a gitsubmodule instead of just moving the code. You could make a testing-cabal/go-subunit repo that we reference on go/.gitmodules.

Anyway, this is ready for review. Let me know what do you think.