### PR TITLE
Add options to output filter to set timestamps

### DIFF
--- a/python/subunit/_output.py
+++ b/python/subunit/_output.py
@@ -22,6 +22,8 @@ from optparse import (
 )
 import sys
 
+from dateutil import parser as date_parser
+
 from subunit import make_stream_binary
 from subunit.iso8601 import UTC
 from subunit.v2 import StreamResultToBytes
@@ -121,6 +123,18 @@ def parse_arguments(args=None, ParserClass=OptionParser):
         dest="tags",
         default=[]
     )
+    parser.add_option(
+        "--start-time",
+        help="Specify a time for the test to start",
+        dest="start_time",
+        default=None
+    )
+    parser.add_option(
+        "--stop-time",
+        help="Specify a time for the test to finish executing",
+        dest="stop_time",
+        default=None
+    )
 
     (options, args) = parser.parse_args(args)
     if options.mimetype and not options.attach_file:
@@ -152,6 +166,14 @@ def set_status_cb(option, opt_str, value, parser, status_name):
 
 
 def generate_stream_results(args, output_writer):
+    if args.start_time:
+        start_time = date_parser.parse(args.start_time)
+    else:
+        start_time = None
+    if args.stop_time:
+        stop_time = date_parser.parse(args.stop_time)
+    else:
+        stop_time = None
     output_writer.startTestRun()
 
     if args.attach_file:
@@ -170,6 +192,7 @@ def generate_stream_results(args, output_writer):
                     write_status = partial(write_status, mime_type=args.mimetype)
             if args.tags:
                 write_status = partial(write_status, test_tags=set(args.tags))
+            timestamp = start_time or create_timestamp()
             write_status = partial(write_status, timestamp=create_timestamp())
             if args.action not in _FINAL_ACTIONS:
                 write_status = partial(write_status, test_status=args.action)
@@ -192,7 +215,11 @@ def generate_stream_results(args, output_writer):
 
         if is_last_packet:
             if args.action in _FINAL_ACTIONS:
-                write_status = partial(write_status, test_status=args.action)
+                if stop_time:
+                    write_status = partial(write_status, test_status=args.action,
+                                           timestamp=stop_time)
+                else:
+                    write_status = partial(write_status, test_status=args.action)
 
         write_status()
 

--- a/python/subunit/tests/test_output_filter.py
+++ b/python/subunit/tests/test_output_filter.py
@@ -480,7 +480,7 @@ class TimeStampTests(TestCase):
     _dummy_timestamp = datetime.datetime(1914, 6, 28, 10, 45, 2, 0, UTC)
 
     def setUp(self):
-        super(StatusStreamResultTests, self).setUp()
+        super(TimeStampTests, self).setUp()
         self.patch(_o, 'create_timestamp', lambda: self._dummy_timestamp)
         self.test_id = self.getUniqueString()
 

--- a/python/subunit/tests/test_output_filter.py
+++ b/python/subunit/tests/test_output_filter.py
@@ -472,6 +472,69 @@ class StatusStreamResultTests(TestCase):
                 ])
             )
 
+class TimeStampTests(TestCase):
+    scenarios = [
+        (s, dict(status=s, option='--' + s)) for s in _FINAL_ACTIONS
+    ]
+
+    _dummy_timestamp = datetime.datetime(1914, 6, 28, 10, 45, 2, 0, UTC)
+
+    def setUp(self):
+        super(StatusStreamResultTests, self).setUp()
+        self.patch(_o, 'create_timestamp', lambda: self._dummy_timestamp)
+        self.test_id = self.getUniqueString()
+
+    def test_no_timestamps(self):
+        result = get_result_for([self.option, self.test_id, f.name])
+        self.assertThat(
+            result._events,
+            MatchesListwise([
+                MatchesStatusCall(call='startTestRun'),
+                MatchesStatusCall(test_id=self.test_id, timestamp=self._dummy_timestamp),
+                MatchesStatusCall(test_id=self.test_id, timestamp=None),
+                MatchesStatusCall(call='stopTestRun'),
+            ]))
+
+    def test_only_start_timestamp(self):
+        timestamp = datetime.datetime.utcnow()
+        result = get_result_for([self.option, self.test_id, f.name,
+                                 '--start-time', timestamp.isoformat()])
+        self.assertThat(
+            result._events,
+            MatchesListwise([
+                MatchesStatusCall(call='startTestRun'),
+                MatchesStatusCall(test_id=self.test_id, timestamp=timestamp),
+                MatchesStatusCall(test_id=self.test_id, timestamp=None),
+                MatchesStatusCall(call='stopTestRun'),
+            ]))
+
+    def test_only_stop_timestamp(self):
+        timestamp = datetime.datetime.utcnow()
+        result = get_result_for([self.option, self.test_id, f.name,
+                                 '--stop-time', timestamp.isoformat()])
+        self.assertThat(
+            result._events,
+            MatchesListwise([
+                MatchesStatusCall(call='startTestRun'),
+                MatchesStatusCall(test_id=self.test_id, timestamp=self._dummy_timestamp),
+                MatchesStatusCall(test_id=self.test_id, timestamp=timestamp),
+                MatchesStatusCall(call='stopTestRun'),
+            ]))
+
+    def test_start_and_stop_timestamp(self):
+        timestamp_start = datetime.datetime.utcnow()
+        timestamp_stop = timestamp_start + datetime.timedelta(minutes=5)
+        result = get_result_for([self.option, self.test_id, f.name,
+                                 '--start-time', timestamp_start.isoformat(),
+                                 '--stop-time', timestamp_stop.isoformat()])
+        self.assertThat(
+            result._events,
+            MatchesListwise([
+                MatchesStatusCall(call='startTestRun'),
+                MatchesStatusCall(test_id=self.test_id, timestamp=timestamp_start),
+                MatchesStatusCall(test_id=self.test_id, timestamp=timestamp_stop),
+                MatchesStatusCall(call='stopTestRun'),
+            ]))
 
 class FileDataTests(TestCase):
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ else:
         'install_requires': [
             'extras',
             'testtools>=0.9.34',
+            'python-dateutil>=2.4.2',
         ],
         'tests_require': [
             'fixtures',


### PR DESCRIPTION
This commit adds 2 new options to subunit-output, --start-time and
--stop-time, to specify a timestamp for the start and end of a test
in the output.
