### PR TITLE
Add ValueError to make_stream_binary

### DIFF
--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -1295,7 +1295,7 @@ def _unwrap_text(stream):
         # Read streams
         if type(stream.read(0)) is unicode_type:
             return stream.buffer
-    except (_UnsupportedOperation, IOError):
+    except (_UnsupportedOperation, IOError, ValueError):
         # Cannot read from the stream: try via writes
         try:
             stream.write(_b(''))


### PR DESCRIPTION
In some cases (and some versions of python) attempting to read
from a file handle that is opened in "write" only mode will result
incorrectly in a `ValueError` being raised instead of an `IOError` or
`_UnsupportedOperation`. Notably this incorrect `ValueError` is
present whe `io.FileIO` is used.

This poses a problem when trying to utilize anything that calls
`subunit.make_stream_binary` as it does an explicit read on the
stream and only catches `IOError` and `_UnsupportedOperation`. This
occurs on many versions of Python 2.7; Python 3 appears to properly
raise `_UnsupportedOperation` in all cases with `io.FileIO`.

The issue can be seen very simply by using `io.FileIO` and opening
any file in "read" mode and then passing it to
`subunit.make_stream_binary`. Below is an example output of
`io.FileIO` and direct use of `open()`:

```
>>> import io
>>> f = io.FileIO('/dev/null', 'w')
>>> f.read(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: File not open for reading

>>> f = open('/dev/null', 'w')
>>> f.read(0)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IOError: File not open for reading
```

The simplest correction is to also catch ValueError in
`subunit._unwrap_text_stream()` on the call to "stream.read(0).
