### PR TITLE
Fallback to reading one-byte-at-a-time if select.select fails

### DIFF
--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -309,6 +309,11 @@ class ByteStreamToStreamResult(object):
             # annoying).
             buffered = [content]
             while len(buffered[-1]):
+                # Note: Windows does not support passing a file descriptor to
+                # select.select. fallback to one-byte-at-a-time.
+                if sys.platform == 'win32':
+                    break
+
                 try:
                     self.source.fileno()
                 except:


### PR DESCRIPTION
select.select does not work on file descriptors on Windows, causing subunit to fail.

Closes-Bug: #1668233