### PR TITLE
Remove test envs that no longer work from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - pypy
-  - pypy3
+  - pypy3.3-5.2-alpha1
 matrix:
   include:
 # Travis nightly look to be 3.5.0a4, b3 is out and the error we see


### PR DESCRIPTION
This commit removes the python 3.2 and pypy3 (which is also python 3.2)
test envs from the travis ci config. These no longer have support for
pypi and pip so there is no reason we should be trying to run them
anymore.

See: https://github.com/testing-cabal/testrepository/pull/28 for more
information.