### PR TITLE
Update release notes for 1.2.0 release

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -2,8 +2,18 @@
 subunit release notes
 ---------------------
 
-NEXT (In development)
----------------------
+1.2.0
+-----
+
+BUGFIXES
+~~~~~~~~
+
+* Fix make_stream_binary with FileIO object inputs.
+  (Matthew Treinish)
+
+* Fix v2 run() on windows platforms.
+  (Claudiu Belu)
+
 
 IMPROVEMENTS
 ~~~~~~~~~~~~


### PR DESCRIPTION
Most of the ground work for the 1.2.0 release was already prepared in
commit 2a4d9f61312bf388e3f909bb58c5237d556f8770. But, the release was
never pushed. This commit updates the release notes for the changes
between that and current HEAD in preparation for actually pushing the
release.