### PR TITLE
Bump pypy3 to version 3.5; also test on cpython 3.5 and 3.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,10 @@ python:
   - "2.7"
   - "3.3"
   - "3.4"
+  - "3.5"
+  - "3.6"
   - pypy
-  - pypy3.3-5.2-alpha1
+  - pypy3.5
 matrix:
   include:
 # Travis nightly look to be 3.5.0a4, b3 is out and the error we see


### PR DESCRIPTION
This should address the lack of get_terminal_size in the os module, which was resolved in https://bitbucket.org/pypy/pypy/issues/2316/osget_terminal_size-is-missing-on-pypy3-hg