### PR TITLE
Check written bytes are not None before summing them to offset

### DIFF
--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -223,6 +223,8 @@ class StreamResultToBytes(object):
             offset = 0
             while offset < datalen:
                 written = self.output_stream.write(view[offset:])
+                if written is None:
+                    break
                 offset += written
         else:
             self.output_stream.write(data)


### PR DESCRIPTION
Because purely written streams could return ```None``` instead of actual written
bytes, we cannot sum them to ```offset``` integer. On such case let
assume data has been written all at once.

This fixes LaunchPad [#1845631](https://bugs.launchpad.net/subunit/+bug/1845631)