### PR TITLE
Remove broken Python 2.6 travis CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ addons:
       - libcppunit-dev
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"


### PR DESCRIPTION
Travis CI JOB is not able to download a file required to run tests with Python 2.6

```
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/python/binaries/ubuntu/16.04/x86_64/python-2.6.tar.bz2
0.12s$ curl -sSf -o python-2.6.tar.bz2 ${archive_url}
curl: (22) The requested URL returned error: 404 Not Found
Unable to download 2.6 archive. The archive may not exist. Please consider a different version.
```
