### PR TITLE
Work around 'short read' race

### DIFF
--- a/python/subunit/tests/test_test_protocol2.py
+++ b/python/subunit/tests/test_test_protocol2.py
@@ -356,7 +356,7 @@ class TestByteStreamToStreamResult(TestCase):
         packet_data = b'\xb3!@\xc0\x00\x11'
         self.check_events(packet_data, [
             self._event(test_id="subunit.parser", eof=True,
-                file_name="Packet data", file_bytes=b'\xb3',
+                file_name="Packet data", file_bytes=packet_data,
                 mime_type="application/octet-stream"),
             self._event(test_id="subunit.parser", test_status="fail", eof=True,
                 file_name="Parser Error",

--- a/python/subunit/tests/test_test_protocol2.py
+++ b/python/subunit/tests/test_test_protocol2.py
@@ -356,7 +356,7 @@ class TestByteStreamToStreamResult(TestCase):
         packet_data = b'\xb3!@\xc0\x00\x11'
         self.check_events(packet_data, [
             self._event(test_id="subunit.parser", eof=True,
-                file_name="Packet data", file_bytes=packet_data,
+                file_name="Packet data", file_bytes=b'\xb3',
                 mime_type="application/octet-stream"),
             self._event(test_id="subunit.parser", test_status="fail", eof=True,
                 file_name="Parser Error",

--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -83,7 +83,7 @@ def read_exactly(stream, size):
     remaining = size
     while remaining:
         read = stream.read(remaining)
-        if not len(read):
+        if len(read) == 0:
             raise ParseError('Short read - got %d bytes, wanted %d bytes' % (
                 len(data), size))
         data += read
@@ -426,9 +426,9 @@ class ByteStreamToStreamResult(object):
     def _parse(self, packet, result):
         # 2 bytes flags, at most 3 bytes length.
         header = read_exactly(self.source, 5)
+        packet.append(header)
         flags = struct.unpack(FMT_16, header[:2])[0]
         length, consumed = self._parse_varint(header, 2, max_3_bytes=True)
-        packet.append(header)
 
         remainder = read_exactly(self.source, length - 6)
         if consumed != 3:

--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -72,13 +72,32 @@ def has_nul(buffer_or_bytes):
         return NUL_ELEMENT in buffer_or_bytes
 
 
+def read_exactly(stream, size):
+    """Read exactly size bytes from stream.
+
+    :param stream: A file like object to read bytes from. Must support
+        read(<count>) and return bytes.
+    :param size: The number of bytes to retrieve.
+    """
+    data = b''
+    remaining = size
+    while remaining:
+        read = stream.read(remaining)
+        if not len(read):
+            raise ParseError('Short read - got %d bytes, wanted %d bytes' % (
+                len(data), size))
+        data += read
+        remaining -= len(read)
+    return data
+
+
 class ParseError(Exception):
     """Used to pass error messages within the parser."""
 
 
 class StreamResultToBytes(object):
     """Convert StreamResult API calls to bytes.
-    
+
     The StreamResult API is defined by testtools.StreamResult.
     """
 
@@ -276,7 +295,7 @@ class ByteStreamToStreamResult(object):
 
     def run(self, result):
         """Parse source and emit events to result.
-        
+
         This is a blocking call: it will run until EOF is detected on source.
         """
         self.codec.reset()
@@ -406,21 +425,12 @@ class ByteStreamToStreamResult(object):
 
     def _parse(self, packet, result):
         # 2 bytes flags, at most 3 bytes length.
-        packet.append(self.source.read(5))
-        if len(packet[-1]) != 5:
-            raise ParseError(
-                'Short read - got %d bytes, wanted 5' % len(packet[-1]))
+        header = read_exactly(self.source, 5)
+        flags = struct.unpack(FMT_16, header[:2])[0]
+        length, consumed = self._parse_varint(header, 2, max_3_bytes=True)
+        packet.append(header)
 
-        flag_bytes = packet[-1][:2]
-        flags = struct.unpack(FMT_16, flag_bytes)[0]
-        length, consumed = self._parse_varint(
-            packet[-1], 2, max_3_bytes=True)
-        remainder = self.source.read(length - 6)
-        if len(remainder) != length - 6:
-            raise ParseError(
-                'Short read - got %d bytes, wanted %d bytes' % (
-                    len(remainder), length - 6))
-
+        remainder = read_exactly(self.source, length - 6)
         if consumed != 3:
             # Avoid having to parse torn values
             packet[-1] += remainder
@@ -533,4 +543,3 @@ class ByteStreamToStreamResult(object):
             return utf8, length+pos
         except UnicodeDecodeError:
             raise ParseError('UTF8 string at offset %d is not UTF8' % (pos-2,))
-


### PR DESCRIPTION
We parse packets inside a loop. When there's a large amount of captured
data, we see error messages like the following:

  Captured Packet data:
  ~~~~~~~~~~~~~~~~~~~~~
      b'\xb3+`Pr^'

  Captured Parser Error:
  ~~~~~~~~~~~~~~~~~~~~~~
      b'Short read - got 108 bytes, wanted 4204 bytes'

Interestingly, if you scan through the logs, you'll see the following
combination popping up (varies between test run):

  Short read - got 108 bytes, wanted 4204 bytes
  Short read - got 4090 bytes, wanted 4204 bytes

These come in the wrong order because things are running in parallel,
but it's obvious that we're not waiting long enough to parse things and
are racing as a result. The solution seems obvious - if we don't get
enough packets, try again before we actually bail out.

Signed-off-by: Stephen Finucane <stephenfin@redhat.com>
Partial-bug: #1813147