### PR TITLE
fix CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,11 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - pypy
   - pypy3.5
+  - pypy3.6
+  - pypy3.7
 matrix:
   include:
 # Travis nightly look to be 3.5.0a4, b3 is out and the error we see

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: focal
 addons:
   apt:
     packages:
@@ -12,15 +13,12 @@ python:
   - "3.7"
   - "3.8"
   - "3.9"
-  - pypy
-  - pypy3.5
-  - pypy3.6
-  - pypy3.7
+  - "pypy2.7-7.3.1"
+  - "pypy3.6-7.3.1"
 matrix:
   include:
-# Travis nightly look to be 3.5.0a4, b3 is out and the error we see
-# doesn't happen in trunk.
-#    - python: "nightly"
+    - dist: xenial
+      python: pypy3.5-7.0.0
 install:
  - pip install -U pip
  - pip install -U wheel setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/python/subunit/tests/test_subunit_tags.py
+++ b/python/subunit/tests/test_subunit_tags.py
@@ -56,6 +56,8 @@ class TestSubUnitTags(testtools.TestCase):
                 b'\x83\x1b\x04test\x03\x03bar\x03foo\x04quux\xd2\x18\x1bC',
             b'\xb3)\x82\x17\x04test\x02\x03foo\x04quux\xa6\xe1\xde\xec\xb3)'
                 b'\x83\x1b\x04test\x03\x03foo\x03bar\x04quux:\x05e\x80',
+            b'\xb3)\x82\x17\x04test\x02\x03foo\x04quux\xa6\xe1\xde\xec\xb3)'
+                b'\x83\x1b\x04test\x03\x04quux\x03foo\x03bar\xaf\xbd\x9d\xd6',
             ]
         stream = subunit.StreamResultToBytes(self.original)
         stream.status(

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Testing',
     ],
     keywords='python test streaming',

--- a/setup.py
+++ b/setup.py
@@ -90,5 +90,6 @@ setup(
         'filters/subunit2pyunit',
         'filters/tap2subunit',
     ],
+    python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*",
     **extra
 )


### PR DESCRIPTION
* Drop py3.4 - we cannot test with it on Travis anymore
* use focal where possible (xenial for pypy3.5)
* add a missing subunit tag reference