### PR TITLE
Don't explicitly build-require wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=43.0.0"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Don't explicitly build-require wheel

See https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a
