### PR TITLE
handle '_DuplicateWriter' object has no attribute 'buffer'

### DIFF
--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -507,7 +507,11 @@ class TestProtocolServer(object):
         """
         self.client = ExtendedToOriginalDecorator(client)
         if stream is None:
-            stream = sys.stdout.buffer
+            if hasattr(sys.stdout, 'buffer'):
+                stream = sys.stdout.buffer
+            else:
+                stream = sys.stdout
+
         self._stream = stream
         self._forward_stream = forward_stream or DiscardStream()
         # state objects we can switch too

--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -172,7 +172,11 @@ def is_stdout_DuplicateWriter(sys_stdout):
     """
     xmlrunner_module = 'xmlrunner'
     if xmlrunner_module in sys.modules:
-        return isinstance(sys_stdout, sys.modules[xmlrunner_module].result._DuplicateWriter)
+        if hasattr(sys.modules[xmlrunner_module], 'result'):
+            if hasattr(sys.modules[xmlrunner_module].result, '_DuplicateWriter'):
+                return isinstance(sys_stdout, sys.modules[xmlrunner_module].result._DuplicateWriter)
+
+        return False
     else:
         return False
 

--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -157,8 +157,6 @@ PROGRESS_CUR = 1
 PROGRESS_PUSH = 2
 PROGRESS_POP = 3
 
-from typing import TYPE_CHECKING, Optional, Type
-
 
 def is_stdout_DuplicateWriter(sys_stdout):
     """

--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -158,6 +158,24 @@ PROGRESS_CUR = 1
 PROGRESS_PUSH = 2
 PROGRESS_POP = 3
 
+from typing import TYPE_CHECKING, Optional, Type
+
+
+def is_stdout_DuplicateWriter(sys_stdout):
+    """
+    Returns a boolean, type checking sys.stdout to see if it was overriden by the unittest-xml-reporting
+    module without importing, matching type xmlrunner.result._DuplicateWriter.
+
+    @param sys_stdout: The current sys.stdout object.
+
+    @return: (bool) True if of type xmlrunner.result._DuplicateWriter, else False.
+    """
+    xmlrunner_module = 'xmlrunner'
+    if xmlrunner_module in sys.modules:
+        return isinstance(sys_stdout, sys.modules[xmlrunner_module].result._DuplicateWriter)
+    else:
+        return False
+
 
 def test_suite():
     import subunit.tests
@@ -510,7 +528,9 @@ class TestProtocolServer(object):
             if hasattr(sys.stdout, 'buffer'):
                 stream = sys.stdout.buffer
             else:
-                stream = sys.stdout
+                # check if sys.stdout was overridden by unittest-xml-reporting module with no buffer
+                if is_stdout_DuplicateWriter(sys.stdout):
+                    stream = sys.stdout
 
         self._stream = stream
         self._forward_stream = forward_stream or DiscardStream()


### PR DESCRIPTION
Handle error case (I believe due to the unittest-xml-reporting module) where sys.stdout has no buffer attribute, causing a failure and hang in subunit:

    protocol = TestProtocolServer(result, self._passthrough, self._forward)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/subunit/__init__.py", line 510, in __init__
    stream = sys.stdout.buffer
             ^^^^^^^^^^^^^^^^^
AttributeError: '_DuplicateWriter' object has no attribute 'buffer'

unittest-xml-reporting/result.py overriding sys.stdout, which doesn't include a buffer:

    def _setupStdout(self):
        """
        Capture stdout / stderr by replacing sys.stdout / sys.stderr
        """
        super(_XMLTestResult, self)._setupStdout()
        self.__stdout_saved = sys.stdout
        sys.stdout = _DuplicateWriter(sys.stdout, self._stdout_capture)
        self.__stderr_saved = sys.stderr
        sys.stderr = _DuplicateWriter(sys.stderr, self._stderr_capture)
