### PR TITLE
Drop extras

### DIFF
--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -124,7 +124,6 @@ import subprocess
 import sys
 import unittest
 
-from extras import safe_hasattr
 from testtools import content, content_type, ExtendedToOriginalDecorator
 from testtools.content import TracebackContent
 from testtools.compat import _b, _u

--- a/python/subunit/filters.py
+++ b/python/subunit/filters.py
@@ -17,7 +17,6 @@
 from optparse import OptionParser
 import sys
 
-from extras import safe_hasattr
 from testtools import CopyStreamResult, StreamResult, StreamResultRouter
 
 from subunit import (
@@ -183,7 +182,7 @@ def run_filter_script(result_factory, description, post_run_hook=None,
         input_stream=find_stream(sys.stdin, args))
     if post_run_hook:
         post_run_hook(result)
-    if not safe_hasattr(result, 'wasSuccessful'):
+    if not hasattr(result, 'wasSuccessful'):
         result = result.decorated
     if result.wasSuccessful():
         sys.exit(0)

--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -14,15 +14,13 @@
 #  limitations under that license.
 #
 
+import builtins
 import codecs
 import datetime
 import select
 import struct
 import sys
 import zlib
-
-from extras import safe_hasattr, try_imports
-builtins = try_imports(['__builtin__', 'builtins'])
 
 import subunit
 import subunit.iso8601 as iso8601
@@ -448,7 +446,7 @@ class ByteStreamToStreamResult(object):
                 'Bad checksum - calculated (0x%x), stored (0x%x)' % (
                     crc, packet_crc))
 
-        if safe_hasattr(builtins, 'memoryview'):
+        if hasattr(builtins, 'memoryview'):
             body = memoryview(packet[-1])
         else:
             body = packet[-1]

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
     package_dir={'subunit': 'python/subunit'},
     python_requires=">=3.7",
     install_requires=[
-        'extras',
         'testtools>=0.9.34',
     ],
     entry_points={


### PR DESCRIPTION
Drop extras

These were mostly used because we needed both python 2 and python 3
