### PR TITLE
Improve unittest calls

### DIFF
--- a/python/subunit/tests/test_subunit_filter.py
+++ b/python/subunit/tests/test_subunit_filter.py
@@ -92,7 +92,7 @@ xfail todo
         tests_expected = list(map(
             subunit.RemotedTestCase,
             ['passed', 'error', 'skipped', 'todo']))
-        self.assertEquals(tests_expected, tests_included)
+        self.assertEqual(tests_expected, tests_included)
 
     def test_tags_tracked_correctly(self):
         tag_filter = make_tag_filter(['a'], [])
@@ -107,13 +107,14 @@ xfail todo
             "successful: bar\n")
         self.run_tests(result_filter, input_stream)
         foo = subunit.RemotedTestCase('foo')
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', foo),
              ('tags', set(['a']), set()),
              ('addSuccess', foo),
              ('stopTest', foo),
              ],
-            result._events)
+            result._events
+        )
 
     def test_exclude_errors(self):
         filtered_result = unittest.TestResult()
@@ -275,10 +276,12 @@ xfail todo
         result_filter = TestResultFilter(result)
         self.run_tests(result_filter, subunit_stream)
         foo = subunit.RemotedTestCase('foo')
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', foo),
              ('addSkip', foo, {}),
-             ('stopTest', foo), ], result._events)
+             ('stopTest', foo), ],
+            result._events
+        )
 
     def test_renames(self):
         def rename(name):
@@ -290,11 +293,12 @@ xfail todo
             "test: foo\n"
             "successful: foo\n")
         self.run_tests(result_filter, input_stream)
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', 'foo - renamed'),
              ('addSuccess', 'foo - renamed'),
              ('stopTest', 'foo - renamed')],
-            [(ev[0], ev[1].id()) for ev in result._events])
+            [(ev[0], ev[1].id()) for ev in result._events]
+        )
 
 
 class TestFilterCommand(TestCase):

--- a/python/subunit/tests/test_test_protocol.py
+++ b/python/subunit/tests/test_test_protocol.py
@@ -438,8 +438,10 @@ class TestInTestMultipart(unittest.TestCase):
             None, self.protocol._reading_success_details)
         parser = self.protocol._reading_success_details.details_parser
         self.assertNotEqual(None, parser)
-        self.assertTrue(isinstance(parser,
-            subunit.details.MultipartDetailsParser))
+        self.assertIsInstance(
+            parser,
+            subunit.details.MultipartDetailsParser
+        )
 
 
 class TestTestProtocolServerAddError(unittest.TestCase):

--- a/python/subunit/tests/test_test_results.py
+++ b/python/subunit/tests/test_test_results.py
@@ -209,10 +209,12 @@ class TestTagCollapsingDecorator(TestCase):
         tag_collapser.tags(set(['a']), set())
         tag_collapser.tags(set(['b']), set())
         tag_collapser.startTest(self)
-        self.assertEquals(
+        self.assertEqual(
             [('tags', set(['a', 'b']), set([])),
              ('startTest', self),
-             ], result._events)
+             ],
+            result._events
+        )
 
     def test_tags_collapsed_outside_of_tests_are_flushed(self):
         result = ExtendedTestResult()
@@ -224,14 +226,16 @@ class TestTagCollapsingDecorator(TestCase):
         tag_collapser.addSuccess(self)
         tag_collapser.stopTest(self)
         tag_collapser.stopTestRun()
-        self.assertEquals(
+        self.assertEqual(
             [('startTestRun',),
              ('tags', set(['a', 'b']), set([])),
              ('startTest', self),
              ('addSuccess', self),
              ('stopTest', self),
              ('stopTestRun',),
-             ], result._events)
+             ],
+            result._events
+        )
 
     def test_tags_forwarded_after_tests(self):
         test = subunit.RemotedTestCase('foo')
@@ -262,11 +266,12 @@ class TestTagCollapsingDecorator(TestCase):
         tag_collapser.tags(set(['b']), set(['a']))
         tag_collapser.tags(set(['c']), set())
         tag_collapser.stopTest(test)
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', test),
              ('tags', set(['b', 'c']), set(['a'])),
              ('stopTest', test)],
-            result._events)
+            result._events
+        )
 
     def test_tags_collapsed_inside_of_tests_different_ordering(self):
         result = ExtendedTestResult()
@@ -277,11 +282,12 @@ class TestTagCollapsingDecorator(TestCase):
         tag_collapser.tags(set(['a', 'b']), set())
         tag_collapser.tags(set(['c']), set())
         tag_collapser.stopTest(test)
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', test),
              ('tags', set(['a', 'b', 'c']), set()),
              ('stopTest', test)],
-            result._events)
+            result._events
+        )
 
     def test_tags_sent_before_result(self):
         # Because addSuccess and friends tend to send subunit output
@@ -295,12 +301,13 @@ class TestTagCollapsingDecorator(TestCase):
         tag_collapser.tags(set(['a']), set())
         tag_collapser.addSuccess(test)
         tag_collapser.stopTest(test)
-        self.assertEquals(
+        self.assertEqual(
             [('startTest', test),
              ('tags', set(['a']), set()),
              ('addSuccess', test),
              ('stopTest', test)],
-            result._events)
+            result._events
+        )
 
 
 class TestTimeCollapsingDecorator(TestCase):
@@ -316,7 +323,7 @@ class TestTimeCollapsingDecorator(TestCase):
         tag_collapser = subunit.test_results.TimeCollapsingDecorator(result)
         a_time = self.make_time()
         tag_collapser.time(a_time)
-        self.assertEquals([('time', a_time)], result._events)
+        self.assertEqual([('time', a_time)], result._events)
 
     def test_time_collapsed_to_first_and_last(self):
         # If there are many consecutive time events, only the first and last
@@ -327,8 +334,10 @@ class TestTimeCollapsingDecorator(TestCase):
         for a_time in times:
             tag_collapser.time(a_time)
         tag_collapser.startTest(subunit.RemotedTestCase('foo'))
-        self.assertEquals(
-            [('time', times[0]), ('time', times[-1])], result._events[:-1])
+        self.assertEqual(
+            [('time', times[0]), ('time', times[-1])],
+            result._events[:-1]
+        )
 
     def test_only_one_time_sent(self):
         # If we receive a single time event followed by a non-time event, we
@@ -338,7 +347,7 @@ class TestTimeCollapsingDecorator(TestCase):
         a_time = self.make_time()
         tag_collapser.time(a_time)
         tag_collapser.startTest(subunit.RemotedTestCase('foo'))
-        self.assertEquals([('time', a_time)], result._events[:-1])
+        self.assertEqual([('time', a_time)], result._events[:-1])
 
     def test_duplicate_times_not_sent(self):
         # Many time events with the exact same time are collapsed into one
@@ -349,7 +358,7 @@ class TestTimeCollapsingDecorator(TestCase):
         for i in range(5):
             tag_collapser.time(a_time)
         tag_collapser.startTest(subunit.RemotedTestCase('foo'))
-        self.assertEquals([('time', a_time)], result._events[:-1])
+        self.assertEqual([('time', a_time)], result._events[:-1])
 
     def test_no_times_inserted(self):
         result = ExtendedTestResult()
@@ -360,11 +369,13 @@ class TestTimeCollapsingDecorator(TestCase):
         tag_collapser.startTest(foo)
         tag_collapser.addSuccess(foo)
         tag_collapser.stopTest(foo)
-        self.assertEquals(
+        self.assertEqual(
             [('time', a_time),
              ('startTest', foo),
              ('addSuccess', foo),
-             ('stopTest', foo)], result._events)
+             ('stopTest', foo)],
+            result._events
+        )
 
 
 class TestByTestResultTests(testtools.TestCase):


### PR DESCRIPTION
Improve unittest calls

reformatted python/subunit/tests/test_subunit_filter.py
reformatted python/subunit/tests/test_test_results.py
reformatted python/subunit/tests/test_test_protocol.py
All done! 3 reformatted, 13 left unchanged
