### PR TITLE
Remove use of deprecated `datetime.datetime` methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -5,6 +5,9 @@ subunit release notes
 NEXT (In development)
 ---------------------
 
+* Removed use of deprecated "utc" and "utcfromtimestamp"
+  methods of "datetime.datetime".  (Jake Lishman)
+
 1.4.3 (2023-09-17)
 ---------------------
 

--- a/python/subunit/test_results.py
+++ b/python/subunit/test_results.py
@@ -192,7 +192,7 @@ class AutoTimingTestResultDecorator(HookedTestResultDecorator):
         time = self._time
         if time is not None:
             return
-        time = datetime.datetime.utcnow().replace(tzinfo=iso8601.UTC)
+        time = datetime.datetime.now(tz=iso8601.UTC)
         self.decorated.time(time)
 
     def progress(self, offset, whence):

--- a/python/subunit/v2.py
+++ b/python/subunit/v2.py
@@ -46,7 +46,7 @@ FLAG_TAGS = 0x0080
 FLAG_MIME_TYPE = 0x0020
 FLAG_EOF = 0x0010
 FLAG_FILE_CONTENT = 0x0040
-EPOCH = datetime.datetime.utcfromtimestamp(0).replace(tzinfo=iso8601.UTC)
+EPOCH = datetime.datetime.fromtimestamp(0, tz=iso8601.UTC)
 NUL_ELEMENT = b'\0'[0]
 # Contains True for types for which 'nul in thing' falsely returns false.
 _nul_test_broken = {}


### PR DESCRIPTION
The methods `datetime.datetime.utc` and `.utcfromtimestamp` were marked deprecated in Python 3.12 in favour of `now(tz=datetime.timezone.utc)` and `fromtimestamp(tz=datetime.timezone.utc)` [^1].

The deprecation does note that there's a small slowdown from the newer methods, but it's on the order of a microsecond.  I didn't change any of the use of `iso8601.UTC` into `datetime.timezone.utc`, but in practice the `iso8601` module just re-exports the standard-library object as its own `UTC` object.

[^1]: https://github.com/python/cpython/issues/103857