### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.7']
         os: ['ubuntu-latest']
     steps:
       - uses: actions/checkout@v4

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Testing',
     ],
     keywords='python test streaming',


### PR DESCRIPTION
This commit adds explicit support and testing for Python 3.12 to python-subunit. Since #71 everything should be working fine when running python-subunit with 3.12, this commit adds CI tests to verify this on every commit and also marks 3.12 as explicitly supported in the trove classifiers in the package metadata.