### PR TITLE
Add addDuration method for Python 3.12

### DIFF
--- a/python/subunit/test_results.py
+++ b/python/subunit/test_results.py
@@ -107,6 +107,10 @@ class TestResultDecorator:
     def time(self, a_datetime):
         return self.decorated.time(a_datetime)
 
+    # Python 3.12 addition: https://docs.python.org/3.12/library/unittest.html#unittest.TestResult.addDuration
+    def addDuration(self, test, duration):
+        return self.decorated.addDuration(test, duration)
+
 
 class HookedTestResultDecorator(TestResultDecorator):
     """A TestResult which calls a hook on every event."""


### PR DESCRIPTION
There is no "Issues" section for this project, so please consider this PR as both a report and a proposed fix.

Python 3.12 introduced the `addDuration` method for `TestResult` instances:

https://docs.python.org/3.12/library/unittest.html#unittest.TestResult.addDuration

Having this missing in `TestResultDecorator` results in many warnings of the following kind when run under Python 3.12 or newer:

```
unittest/case.py:597: RuntimeWarning: TestResult has no addDuration method
```

Adding this method to the pass-through decorator seems to clear up the error, but I'm not in a position to claim that this is a 100% correct fix.