### PR TITLE
Fix ExecTestCase to properly handle shell scripts

### DIFF
--- a/python/subunit/__init__.py
+++ b/python/subunit/__init__.py
@@ -907,12 +907,7 @@ class ExecTestCase(unittest.TestCase):
 
     def _run(self, result):
         protocol = TestProtocolServer(result)
-        # Explicitly invoke Python to run the script instead of relying on
-        # execute permissions, which may not be preserved during installation
-        import shlex
-
-        script_parts = shlex.split(self.script)
-        process = subprocess.Popen([sys.executable] + script_parts, stdout=subprocess.PIPE)
+        process = subprocess.Popen(self.script, shell=True, stdout=subprocess.PIPE)
         make_stream_binary(process.stdout)
         output = process.communicate()[0]
         protocol.readFrom(BytesIO(output))


### PR DESCRIPTION
Use shell=True to let the shell parse and execute shebangs properly. The previous approach of always using sys.executable broke shell script tests since it tried to run .sh files with the Python interpreter.